### PR TITLE
Add support to mock a send command used by a connected socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 node_modules
 npm-debug.log
+package-lock.json

--- a/lib/mock-udp.js
+++ b/lib/mock-udp.js
@@ -46,6 +46,16 @@ function overriddenSocketSend(buffer, offset, length, port, address, callback) {
 overriddenSocketSend._mocked = true;
 
 
+function overriddenSocketConnect(port, address = '127.0.0.1', cb = () => {}) {
+  this.send = (buffer, callback) => {
+    console.log('repara que esse individuo chegou aqui...')
+    return overriddenSocketSend(buffer, null, null, port, address, callback)
+  }
+  cb()
+}
+overriddenSocketConnect._mocked = true;
+
+
 var intercepts = {};
 function add(path) {
     if (!intercepts.hasOwnProperty(path)) {
@@ -61,19 +71,24 @@ function cleanInterceptions() {
 }
 
 var oldSocketSend = Socket.prototype.send;
-function restoreSocketSend() {
+var oldSocketConnect = Socket.prototype.connect;
+function restoreSocketPrototype() {
     Socket.prototype.send = oldSocketSend;
+    Socket.prototype.connect = oldSocketConnect
 }
 
-// Punch Socket.send in the mouth
-function interceptSocketSend() {
+// Punch Socket prototype in the mouth
+function interceptSocketPrototype() {
     Socket.prototype.send = overriddenSocketSend;
+    Socket.prototype.connect = overriddenSocketConnect;
 }
-interceptSocketSend();
+interceptSocketPrototype();
 
 module.exports = add;
-module.exports.revert = restoreSocketSend;
-module.exports.intercept = interceptSocketSend;
+module.exports.revert = restoreSocketPrototype;
+module.exports.intercept = interceptSocketPrototype;
 module.exports.clean = cleanInterceptions;
-module.exports.isMocked = function() { return Socket.prototype.send.hasOwnProperty('_mocked'); }
+module.exports.isMocked = function() { 
+  return Socket.prototype.send.hasOwnProperty('_mocked') && Socket.prototype.connect.hasOwnProperty('_mocked')
+}
 module.exports.version = require('../package.json').version;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Matt Robenolt <matt@ydekproductions.com>",
   "license": "BSD",
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 12.0.0"
   },
   "dependencies": {},
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -16,7 +16,7 @@ describe('mock-udp.version', function(){
 });
 
 describe('mock-udp.intercept', function(){
-    it('should have punched Socket.prototype.send in the face', function(){
+    it('should have punched Socket.prototype.send and Socket.prototype.connect in the face', function(){
         mockudp.intercept();
         mockudp.isMocked().should.be.ok;
         mockudp.revert();


### PR DESCRIPTION
With the dgram module update, now it is possible to use a connected socket to send data through it.  

This MR aims to give support this new way of using. 